### PR TITLE
Fix babelrc so antd-mobile is included not just in development

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,4 @@
 {
   "presets": ["babel-preset-expo"],
-  "env": {
-    "development": {
-      "plugins": [["import", { "libraryName": "antd-mobile" }]]
-    }
-  }
+  "plugins": [["import", { "libraryName": "antd-mobile" }]]
 }


### PR DESCRIPTION
I repro'd the error you mentioned in https://forums.expo.io/t/problem-with-expo-publishing/4958/3 by doing `exp start --no-dev` (if you try this, make sure to do `exp start --dev` next time you start the packager to go back into dev mode) and saw the same error you mentioned, followed byanother error message from antd-mobile saying that you need to use the babel plugin. So I looked in babelrc and saw it was only configured for development. Changed the babelrc then did `exp start -c` to clear the cache and it worked.